### PR TITLE
feat(auth): create login (with token in localStorage) and registration hooks

### DIFF
--- a/src/hooks/useLogin.tsx
+++ b/src/hooks/useLogin.tsx
@@ -1,0 +1,36 @@
+import api from "../api/axios";
+import { useMutation } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+
+interface LoginPayload {
+  email: string;
+  password: string;
+}
+
+interface LoginResponse {
+  token: string;
+}
+
+const useLogin = () => {
+  return useMutation({
+    mutationFn: async (payload: LoginPayload): Promise<LoginResponse> => {
+      try {
+        const { data } = await api.post<LoginResponse>("/auth/login", payload);
+        localStorage.setItem("token", data.token);
+        console.log(data);
+        return data;
+      } catch (error: unknown) {
+        if (error instanceof AxiosError) {
+          const message = error.response?.data
+            ? (error.response.data as string)
+            : "Unknown error during login";
+          throw new Error(message);
+        } else {
+          throw new Error("Unknown error during login");
+        }
+      }
+    },
+  });
+};
+
+export default useLogin;

--- a/src/hooks/useRegister.tsx
+++ b/src/hooks/useRegister.tsx
@@ -1,0 +1,38 @@
+import { useMutation } from "@tanstack/react-query";
+import api from "../api/axios";
+import { AxiosError } from "axios";
+
+interface RegisterData {
+  name: string;
+  lastname: string;
+  email: string;
+  password: string;
+}
+
+const useRegister = () => {
+  return useMutation<unknown, Error, RegisterData>({
+    mutationFn: async (data: RegisterData) => {
+      try {
+        const response = await api.post("/auth/register", data);
+        console.log("Response:", response.data);
+      } catch (error: unknown) {
+        if (error instanceof AxiosError) {
+          const message = error.response?.data
+            ? (error.response.data as string)
+            : "Unknown error during registration";
+          throw new Error(message);
+        } else {
+          throw new Error("Unknown error during registration");
+        }
+      }
+    },
+    onSuccess: () => {
+      console.log("Registration successful");
+    },
+    onError: (error) => {
+      console.error("Error during registration: ", error.message);
+    },
+  });
+};
+
+export default useRegister;


### PR DESCRIPTION
Implementation of login and registration hooks, connecting to the auth/login and auth/register endpoints. The received token is stored in localStorage to persist the user's session.

We dont have the backend real domains yet to set it in the axios api configuration, but the post was tested in public post domains and it works.